### PR TITLE
(plugin.vim) fix: neobundle#rcがneobundle.vimv3.1から利用不可能

### DIFF
--- a/myconf/plugin.vim
+++ b/myconf/plugin.vim
@@ -25,7 +25,9 @@ if has('vim_starting')
     "自身のNeoBundleを置いている場所
     execute 'set runtimepath+=' . expand('~/.vim/bundle/neobundle.vim')
   endif
-  call neobundle#rc(expand('~/.vim/bundle'))
+  call neobundle#begin(expand('~/.vim/bundle/'))
+  NeoBundleFetch 'Shougo/neobundle.vim'
+  call neobundle#end()
 endif
 
 NeoBundle 'kchmck/vim-coffee-script.git'


### PR DESCRIPTION
tjknです．
githubのvimrcが最新版か存じ上げませんが，調子に乗ってpull requestです．

neobundle.vim ver3.1dev から正式にneobundle#rcが削除され，利用できなくなったので
neobundle#rcをneobundle#bigin~neobundle#endに変更しておきました．

[https://github.com/Shougo/neobundle.vim/commit/513e9d8e5883bea9affd7b9d31ca5657d3d9b16f](https://github.com/Shougo/neobundle.vim/commit/513e9d8e5883bea9affd7b9d31ca5657d3d9b16f)
